### PR TITLE
Replace .jsx requires in .js to be able to require e.g. timeago using browserify

### DIFF
--- a/prepublish.js
+++ b/prepublish.js
@@ -21,6 +21,7 @@ for (var i = 0; i < files.length; i++) {
 
     var js = fs.readFileSync(src, {encoding: 'utf8'});
     var transformed = jstransform.transform(visitorList, js).code;
+    transformed = transformed.replace('.jsx', '.js');
 
     fs.writeFileSync(dest, transformed);
 }


### PR DESCRIPTION
It's a bit a ugly hack but otherwise the `require()` call in the built `timeago.js` doesn't work.
Another option would be to rename all `js/*.jsx` files to `js/*.js` - I don't really see the point of having a different extension there, to be honest :) But this is my personal opinion and might conflict with your coding guidelines.
