### PR TITLE
Allow LayeredComponentMixin renderLayer() to return null

### DIFF
--- a/js/layered-component-mixin.jsx
+++ b/js/layered-component-mixin.jsx
@@ -39,7 +39,17 @@ var LayeredComponentMixin = {
         // componentDidUpdate(), you're effectively creating a "wormhole" that
         // funnels React's hierarchical updates through to a DOM node on an
         // entirely different part of the page.
-        React.render(this.renderLayer(), this._layer);
+
+        var layerElement = this.renderLayer();
+        // Renders can return null, but React.render() doesn't like being asked
+        // to render null. If we get null back from renderLayer(), just render
+        // a noscript element, like React does when an element's render returns
+        // null.
+        if (layerElement === null) {
+            React.render(<noscript />, this._layer);
+        } else {
+            React.render(layerElement, this._layer);
+        }
 
         if (this.layerDidMount) {
             this.layerDidMount(this._layer);

--- a/test/layered-component-mixin-test.jsx
+++ b/test/layered-component-mixin-test.jsx
@@ -1,0 +1,83 @@
+var assert = require("assert");
+var jsdom = require("jsdom");
+var React = require("react");
+var TestUtils = React.addons.TestUtils;
+
+var LayeredComponentMixin = require("../js/layered-component-mixin.jsx");
+
+
+describe("LayeredComponentMixin", function() {
+    beforeEach(function() {
+        global.window = jsdom.jsdom().createWindow();
+        global.document = window.document;
+    });
+
+    it("should render the layer outside of the render area", function() {
+        var Layer = React.createClass({
+            mixins: [LayeredComponentMixin],
+
+            renderLayer: function() {
+                return <div className="layer">This is the layer</div>;
+            },
+
+            render: function() {
+                return <div className="not-layer">This is not a layer</div>;
+            }
+        });
+
+        var layer = TestUtils.renderIntoDocument(<Layer />);
+
+        var layerChildren = TestUtils.scryRenderedDOMComponentsWithClass(
+            layer, "layer");
+        var nonlayerChildren = TestUtils.scryRenderedDOMComponentsWithClass(
+            layer, "not-layer");
+        assert.strictEqual(layerChildren.length, 0);
+        assert.strictEqual(nonlayerChildren.length, 1);
+    });
+
+    it("should render the layer in a div attached to the document body",
+            function() {
+        var Layer = React.createClass({
+            mixins: [LayeredComponentMixin],
+
+            renderLayer: function() {
+                return <div className="layer">This is the layer</div>;
+            },
+
+            render: function() {
+                return <div className="not-layer">This is not a layer</div>;
+            }
+        });
+
+        var layer = TestUtils.renderIntoDocument(<Layer />);
+
+        var layerDOMs = document.getElementsByClassName("layer");
+        assert.strictEqual(layerDOMs.length, 1);
+
+        var layerDOM = layerDOMs[0];
+        var parent = layerDOM.parentNode;
+        assert.strictEqual(parent.tagName, "DIV");
+
+        var grandparent = parent.parentNode;
+        assert.strictEqual(grandparent, document.body);
+    });
+
+    it("should allow empty layers", function() {
+        var EmptyLayer = React.createClass({
+            mixins: [LayeredComponentMixin],
+
+            renderLayer: function() {
+                // An empty layer
+                return null;
+            },
+
+            render: function() {
+                return <div className="not-layer">This is not a layer</div>;
+            }
+        });
+
+        assert.doesNotThrow(function() {
+            TestUtils.renderIntoDocument(<EmptyLayer />);
+        });
+    });
+});


### PR DESCRIPTION
Test Plan:
Ran the included test before and after the change. Saw that "should
allow empty layers" failed before, but passes now.
