### PR TITLE
Enable reactify transformation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Khan Academy",
   "description": "React components used by Khan Academy",
   "homepage": "http://khan.github.io/react-components/",
+  "browserify": {"transform": ["reactify"]},
   "keywords": ["react", "widgets", "react-ui", "react-component", "khan"],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added browserify property to `package.json` to enforce `reactify` transformation when the `react-components` is used as a third-party library inside another project.

See [#25](https://github.com/Khan/react-components/issues/25)
