### PR TITLE
Remove jQuery dependency from Modal component

### DIFF
--- a/js/modal.jsx
+++ b/js/modal.jsx
@@ -1,6 +1,5 @@
 var RCSS = require('rcss');
 var React = require("react");
-var $ = require("jquery");
 
 var modalStyle = {
     position: "fixed",


### PR DESCRIPTION
Doesn’t look like this is actually needed (the docs agree)