### PR TITLE
Sortable no longer depends on Underscore

### DIFF
--- a/js/sortable.jsx
+++ b/js/sortable.jsx
@@ -1,6 +1,4 @@
 var React = require('react');
-var _     = require('underscore');
-
 var PT    = React.PropTypes;
 
 var sortableDragging = {
@@ -24,6 +22,25 @@ var userSelect = rhs => {
 
 var sortableDisabled = userSelect("none");
 
+/**
+ * Behaves like Array.prototype.filter, except it handle any iterable type (not just Arrays).
+ */
+function filter(obj, predicate) {
+    var results = [];
+    for (var i = 0, len = obj.length; i < len; i++) {
+        var value = obj[i];
+        if (predicate(value, i, obj))  results.push(value);
+    }
+    return results;
+}
+
+/**
+ * Return the values from arr1 that are not present in arr2.
+ */
+function difference(arr1, arr2) {
+    return filter(arr1, (each) => {return arr2.indexOf(each) < 0});
+}
+
 // Takes an array of components to sort
 var SortableArea = React.createClass({
     propTypes: {
@@ -32,7 +49,7 @@ var SortableArea = React.createClass({
         verify: PT.func
     },
     render: function() {
-        var sortables = _(this.state.components).map((component, index) =>
+        var sortables = this.state.components.map((component, index) =>
             <SortableItem
                 index={index}
                 component={component}
@@ -110,15 +127,15 @@ var SortableArea = React.createClass({
     _setDragEvents: function() {
         this._dragItems = this._dragItems || [];
         var items = this.getDOMNode().querySelectorAll('[draggable=true]');
-        var oldItems = _(this._dragItems).difference(items);
-        var newItems = _(items).difference(this._dragItems);
+        var oldItems = difference(this._dragItems, items);
+        var newItems = difference(items, this._dragItems);
 
-        _(newItems).each(dragItem => {
+        newItems.forEach(dragItem => {
             dragItem.addEventListener('dragstart', this._listenEvent);
             dragItem.addEventListener('drop',      this._cancelEvent);
         });
 
-        _(oldItems).each(dragItem => {
+        oldItems.forEach(dragItem => {
             dragItem.removeEventListener('dragstart', this._listenEvent);
             dragItem.removeEventListener('drop',      this._cancelEvent);
         });

--- a/js/sortable.jsx
+++ b/js/sortable.jsx
@@ -38,7 +38,7 @@ function filter(obj, predicate) {
  * Return the values from arr1 that are not present in arr2.
  */
 function difference(arr1, arr2) {
-    return filter(arr1, (each) => {return arr2.indexOf(each) < 0});
+    return filter(arr1, (item) => {return arr2.indexOf(item) < 0});
 }
 
 // Takes an array of components to sort

--- a/js/sortable.jsx
+++ b/js/sortable.jsx
@@ -23,22 +23,10 @@ var userSelect = rhs => {
 var sortableDisabled = userSelect("none");
 
 /**
- * Behaves like Array.prototype.filter, except it handle any iterable type (not just Arrays).
- */
-function filter(obj, predicate) {
-    var results = [];
-    for (var i = 0, len = obj.length; i < len; i++) {
-        var value = obj[i];
-        if (predicate(value, i, obj))  results.push(value);
-    }
-    return results;
-}
-
-/**
  * Return the values from arr1 that are not present in arr2.
  */
 function difference(arr1, arr2) {
-    return filter(arr1, (item) => {return arr2.indexOf(item) < 0});
+    return Array.prototype.filter.call(arr1, (item) => {return arr2.indexOf(item) < 0});
 }
 
 // Takes an array of components to sort

--- a/template.html
+++ b/template.html
@@ -241,7 +241,7 @@ avoid breaking backwards compatibility unless absolutely necessary.</pre>
 
         <h3 id="sortable">Sortable</h3>
         {{ stability("unstable") }}
-        {{ depends([("http://underscorejs.org/", "Underscore")]) }}
+        {{ depends([]) }}
         <p>Sort a list.</p>
         {% code_example "sortable.jsx" %}
 


### PR DESCRIPTION
- Add simplified implementation of filter and difference
- Use Array.prototype.map instead of _.map
- Use Array.prototype.forEach instead of _.each
- Update docs
