### PR TITLE
Use locally-installed mocha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ watch-preview: jsdeps
 	./node_modules/.bin/watchify -d -t [ reactify --es6 ] js/*.jsx reactify-components.jsx -o docs/preview-bundle.js
 
 test: jsdeps
-	mocha --reporter spec --compilers jsx:test/compiler.js -r test/test-helper.js test/*test.jsx
+	./node_modules/.bin/mocha --reporter spec --compilers jsx:test/compiler.js -r test/test-helper.js test/*test.jsx


### PR DESCRIPTION
Changes Makefile to use the `mocha` command installed locally by `npm install`. This makes the `test` command more consistent with the other commands and obviates the need to install mocha globally.